### PR TITLE
fix bug

### DIFF
--- a/feifei/vectorstore_utils.py
+++ b/feifei/vectorstore_utils.py
@@ -59,7 +59,7 @@ def load_or_build_vectorstore(
     vectorstore_path = os.path.join(".cache", vectorstore_file)
     repo_state_path = os.path.join(".cache", repo_state_file)
 
-    if os.path.exists(vectorstore_path) and os.path.getsize(vectorstore_path) > 0:
+    if os.path.exists(vectorstore_path) and os.path.getsize(repo_state_path) > 0:
         with open(repo_state_path, "r") as f:
             repo_state = json.load(f)
 
@@ -138,7 +138,7 @@ def load_or_update_vectorstore(
     vectorstore_path = os.path.join(".cache", vectorstore_file)
     repo_state_path = os.path.join(".cache", repo_state_file)
 
-    if os.path.exists(vectorstore_path) and os.path.getsize(vectorstore_path) > 0:
+    if os.path.exists(vectorstore_path) and os.path.getsize(repo_state_path) > 0:
         with open(repo_state_path, "r") as f:
             repo_state = json.load(f)
 


### PR DESCRIPTION
This pull request includes changes to the `feifei/vectorstore_utils.py` file to correct the condition for checking the size of the repository state file instead of the vector store file in two functions.

Code corrections:

* [`feifei/vectorstore_utils.py`](diffhunk://#diff-d7ed8b2eda333e2d9fd56d3b906a4d852c0c0343a336f2f379d1d14c6d706dc4L62-R62): Modified the condition in `load_or_build_vectorstore` to check the size of `repo_state_path` instead of `vectorstore_path`.
* [`feifei/vectorstore_utils.py`](diffhunk://#diff-d7ed8b2eda333e2d9fd56d3b906a4d852c0c0343a336f2f379d1d14c6d706dc4L141-R141): Modified the condition in `load_or_update_vectorstore` to check the size of `repo_state_path` instead of `vectorstore_path`.